### PR TITLE
Allow getting a new client with a context.Context

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,8 @@
 package trello
 
 import (
+	"context"
+	"net/http"
 	"testing"
 )
 
@@ -17,6 +19,51 @@ func TestGetWithBadURL(t *testing.T) {
 	if err == nil {
 		t.Fatal("Get() should fail with a bad URL")
 	}
+}
+
+func TestWithContext(t *testing.T) {
+	c := testClient()
+	if c.ctx != context.Background() {
+		t.Fatal("NewClient() should use context.Background()")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	newC := c.WithContext(ctx)
+	if newC == c {
+		t.Fatal("WithContext() should return a new client")
+	}
+
+	if newC.ctx != ctx {
+		t.Fatal("WithContext() should return a client with the given context")
+	}
+
+	var calls int
+	mt := &mockTransport{
+		RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+			calls++
+			if req.Context() != ctx {
+				t.Fatal("Get() should be using the new context")
+			}
+			return http.DefaultTransport.RoundTrip(req)
+		},
+	}
+	newC.client = &http.Client{
+		Transport: mt,
+	}
+	newC.Get("members", nil, nil)
+
+	if calls != 1 {
+		t.Fatal("Get() should have used the mocked transport")
+	}
+}
+
+type mockTransport struct {
+	RoundTripFunc func(*http.Request) (*http.Response, error)
+}
+
+func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.RoundTripFunc(req)
 }
 
 func testClient() *Client {


### PR DESCRIPTION
Context is great to allow for cancellation of requests.

With this change it will be possible to get a new client which will set
a different context for all its requests.

This solution is backwards-compatible. However, since this package
always embeds itself to provide methods like *Board.GetLists(). The
current solution could lead to memory leaks or using old contexts if the
user is holding the responses in memory.