### PR TITLE
Make client public

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,7 +19,7 @@ import (
 const DEFAULT_BASEURL = "https://api.trello.com/1"
 
 type Client struct {
-	client   *http.Client
+	Client   *http.Client
 	Logger   logger
 	BaseURL  string
 	Key      string
@@ -34,7 +34,7 @@ type logger interface {
 
 func NewClient(key, token string) *Client {
 	return &Client{
-		client:   http.DefaultClient,
+		Client:   http.DefaultClient,
 		BaseURL:  DEFAULT_BASEURL,
 		Key:      key,
 		Token:    token,
@@ -73,7 +73,7 @@ func (c *Client) Get(path string, args Arguments, target interface{}) error {
 		return errors.Wrapf(err, "Invalid GET request %s", url)
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "HTTP request failure on %s", url)
 	}
@@ -115,7 +115,7 @@ func (c *Client) Put(path string, args Arguments, target interface{}) error {
 		return errors.Wrapf(err, "Invalid PUT request %s", url)
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "HTTP request failure on %s", url)
 	}
@@ -158,7 +158,7 @@ func (c *Client) Post(path string, args Arguments, target interface{}) error {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := c.client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "HTTP request failure on %s", url)
 	}
@@ -201,7 +201,7 @@ func (c *Client) Delete(path string, args Arguments, target interface{}) error {
 		return errors.Wrapf(err, "Invalid DELETE request %s", url)
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return errors.Wrapf(err, "HTTP request failure on %s", url)
 	}


### PR DESCRIPTION
to use a proxy specific for trello api, one need to be able to override the http client.