### PR TITLE
update searchOptions Modifiers type

### DIFF
--- a/search.go
+++ b/search.go
@@ -14,10 +14,14 @@ type SearchResult struct {
 }
 
 type SearchOptions struct {
-	Terms      []SearchTerm `json:"terms"`
-	Modifiers  []string     `json:"modifiers,omitempty"`
-	ModelTypes []string     `json:"modelTypes,omitempty"`
-	Partial    bool         `json:"partial"`
+	Terms      []SearchTerm     `json:"terms"`
+	Modifiers  []SearchModifier `json:"modifiers,omitempty"`
+	ModelTypes []string         `json:"modelTypes,omitempty"`
+	Partial    bool             `json:"partial"`
+}
+
+type SearchModifier struct {
+	Text string `json:"text"`
 }
 
 type SearchTerm struct {


### PR DESCRIPTION
I can't find this _exactly_ in documentation as Trello doesn't document expected API responses (🤦‍♂️ ), but when calling the [search](https://developers.trello.com/v1.0/reference#search) endpoint locally and via this repo, I'm getting `JSON` errors:
```
json: cannot unmarshal object into Go struct field SearchOptions.modifiers of type string
```
and upon further inspection of the data returned by that endpoint:
```
$ > curl "https://api.trello.com/1/search?query=board:test&key=XXX&token=XXX" | jq .
{
  "options": {
    "terms": [],
    "modifiers": [
      {
        "text": "board:test"
      }
    ],
    "modelTypes": [],
    "partial": false
  }
}
```
it appears that the `modifiers` data type is indeed no longer an array of `string`s, but an array of `map[string][string]`s. I've updated the `SearchOptions.modifiers` type to reflect that change.