### PR TITLE
re-add client on search endpoint

### DIFF
--- a/search.go
+++ b/search.go
@@ -40,6 +40,9 @@ func (c *Client) SearchBoards(query string, args Arguments) (boards []*Board, er
 	res := SearchResult{}
 	err = c.Get("search", args, &res)
 	boards = res.Boards
+	for _, board := range boards {
+		board.client = c
+	}
 	return
 }
 


### PR DESCRIPTION
Currently, if a list of `Board` objects is retrieved via the [search endpoint](https://github.com/adlio/trello/blob/master/search.go#L37), we're not re-adding the `client` variable back into the board, which results in `nil pointer` errors:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x135f332]

goroutine 1 [running]:
github.com/luccacabra/trello.(*Client).Throttle(...)
	github.com/luccacabra/trello/client.go:56
github.com/luccacabra/trello.(*Client).Get(0x0, 0xc42001c360, 0x25, 0xc42010dd30, 0x1393980, 0xc4201e2240, 0x0, 0x0)
	github.com/luccacabra/trello/client.go:64 +0x52
github.com/luccacabra/trello.(*Board).GetLists(0xc4200926c0, 0xc42010dd30, 0xc42010dd30, 0xc42010dd60, 0xc42010dd30, 0x0, 0x13ab2e0)
	github.com/luccacabra/trello/list.go:40 +0x107
main.TrelloBoard(0xc420014900, 0x20, 0xc420018280, 0x40, 0xc420016958, 0x4, 0x0, 0x0, 0x0, 0x0, ...)
...
```