### PR TITLE
Set client on cards when getting lists

### DIFF
--- a/list.go
+++ b/list.go
@@ -31,6 +31,9 @@ func (c *Client) GetList(listID string, args Arguments) (list *List, err error) 
 	err = c.Get(path, args, &list)
 	if list != nil {
 		list.client = c
+		for i := range list.Cards {
+			list.Cards[i].client = c
+		}
 	}
 	return
 }
@@ -40,6 +43,9 @@ func (b *Board) GetLists(args Arguments) (lists []*List, err error) {
 	err = b.client.Get(path, args, &lists)
 	for i := range lists {
 		lists[i].client = b.client
+		for j := range lists[i].Cards {
+			lists[i].Cards[j].client = b.client
+		}
 	}
 	return
 }

--- a/list_test.go
+++ b/list_test.go
@@ -28,6 +28,21 @@ func TestGetList(t *testing.T) {
 	}
 }
 
+func TestGetListWithCards(t *testing.T) {
+	c := testClient()
+	c.BaseURL = mockResponse("lists", "list-api-example.json").URL
+	list, err := c.GetList("4eea4ff", Defaults())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Cards) == 0 {
+		t.Fatal("cannot test cards as non was available in lists mock response")
+	}
+	if list.Cards[0].client == nil {
+		t.Fatal("client not set on cards")
+	}
+}
+
 func TestGetListsOnBoard(t *testing.T) {
 	board := testBoard(t)
 	board.client.BaseURL = mockResponse("lists", "board-lists-api-example.json").URL
@@ -38,6 +53,23 @@ func TestGetListsOnBoard(t *testing.T) {
 
 	if len(lists) != 3 {
 		t.Errorf("Expected 1 list, got %d", len(lists))
+	}
+}
+
+func TestGetListsOnBoardWithCards(t *testing.T) {
+	board := testBoard(t)
+	board.client.BaseURL = mockResponse("lists", "board-lists-api-example.json").URL
+	lists, err := board.GetLists(Defaults())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range lists {
+		if len(lists[i].Cards) == 0 {
+			t.Fatal("cannot test cards as non was available in lists mock response")
+		}
+		if lists[i].Cards[0].client == nil {
+			t.Fatal("client not set on cards")
+		}
 	}
 }
 


### PR DESCRIPTION
This PR ensures to set `client` on card entities when retrieving lists either directly or through a board.

Closes #18 
