### PR TITLE
Support for adding URL Attachments to a card

### DIFF
--- a/card.go
+++ b/card.go
@@ -262,6 +262,20 @@ func (c *Card) AddComment(comment string, args Arguments) (*Action, error) {
 	return &action, err
 }
 
+func (c *Card) AddURLAttachment(attachment *Attachment)  error {
+	path := fmt.Sprintf("cards/%s/attachments", c.ID)
+	args := Arguments{
+		"url":  attachment.URL,
+		"name": attachment.Name,
+	}
+	err := c.client.Post(path, args, &attachment)
+	if err != nil {
+		err = errors.Wrapf(err, "Error adding attachment to card %s", c.ID)
+	}
+	return err
+
+}
+
 // If this Card was created from a copy of another Card, this func retrieves
 // the originating Card. Returns an error only when a low-level failure occurred.
 // If this Card has no parent, a nil card and nil error are returned. In other words, the

--- a/card_test.go
+++ b/card_test.go
@@ -227,6 +227,22 @@ func TestAddMemberIdToCard(t *testing.T) {
 	}
 }
 
+func TestAddURLAttachmentToCard(t *testing.T) {
+	c := testCard(t)
+	c.client.BaseURL = mockResponse("cards", "url-attachments.json").URL
+	attachment := Attachment{
+		Name: "Test",
+		URL: "https://github.com/test",
+	}
+	err := c.AddURLAttachment(&attachment)
+	if err != nil {
+		t.Error(err)
+	}
+	if attachment.ID != "5bbce18fa4a337483b145a57" {
+		t.Errorf("Expected attachment to pick up an ID, got %v instead", attachment.ID)
+	}
+}
+
 // Utility function to get a simple response from Client.GetCard()
 //
 func testCard(t *testing.T) *Card {

--- a/testdata/cards/url-attachments.json
+++ b/testdata/cards/url-attachments.json
@@ -1,0 +1,14 @@
+{
+  "id":"5bbce18fa4a337483b145a57",
+  "bytes":6654,
+  "date":"2018-10-09T17:12:47.847Z",
+  "edgeColor":null,
+  "idMember":"4eea503d91e31d174600008f",
+  "isUpload":true,
+  "mimeType":null,
+  "name":"test",
+  "previews":[],
+  "url":"https://github.com/adlio/trello/pull/27",
+  "pos":32768,
+  "limits":{}
+}


### PR DESCRIPTION
I find your library really useful, but seems to lack API calls to add attachments onto cards.

This PR covers my use case, which is to link Trello cards with GitHub issues via the GitHub Power-up: https://trello.com/power-ups/55a5d916446f517774210004/github