### PR TITLE
support get my boards

### DIFF
--- a/board.go
+++ b/board.go
@@ -80,6 +80,15 @@ func (c *Client) GetBoard(boardID string, args Arguments) (board *Board, err err
 	return
 }
 
+func (c *Client) GetMyBoards( args Arguments) (boards []*Board, err error) {
+	path := "members/me/boards"
+	err = c.Get(path, args, &boards)
+	for i := range boards {
+		boards[i].client = c
+	}
+	return
+}
+
 func (m *Member) GetBoards(args Arguments) (boards []*Board, err error) {
 	path := fmt.Sprintf("members/%s/boards", m.ID)
 	err = m.client.Get(path, args, &boards)

--- a/board_test.go
+++ b/board_test.go
@@ -76,6 +76,28 @@ func TestGetBoards(t *testing.T) {
 
 }
 
+func TestGetMyBoards(t *testing.T) {
+	c := testClient()
+
+	c.BaseURL = mockResponse("boards", "member-boards-example.json").URL
+	boards, err := c.GetMyBoards(Defaults())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(boards) != 2 {
+		t.Errorf("Expected 2 boards. Got %d", len(boards))
+	}
+
+	if boards[0].Name != "Example Board" {
+		t.Errorf("Name of first board incorrect. Got: '%s'", boards[0].Name)
+	}
+
+	if boards[1].Name != "Public Board" {
+		t.Errorf("Name of second board incorrect. Got: '%s'", boards[1].Name)
+	}
+}
+
 func TestGetUnauthorizedBoard(t *testing.T) {
 	c := testClient()
 	c.BaseURL = mockErrorResponse(401).URL


### PR DESCRIPTION
In the current implementation it is necessary to hit member api to get the board of the user who is attached to api token.

In trello you can use me shortcut as a reference to the user requesting based on api token.
Supports me shortcut to reduce the number of api calls when acquiring user's board associated with api tolken
