### PR TITLE
Added the implementation of 'GetMyNotifications'

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -1,0 +1,53 @@
+package trello
+
+import (
+	"time"
+)
+
+// Notification represents a Trello Notification.
+// https://developers.trello.com/reference/#notifications
+type Notification struct {
+	client *Client
+
+	ID              string           `json:"id"`
+	IDAction        string           `json:"idAction"`
+	Unread          bool             `json:"unread"`
+	Type            string           `json:"type"`
+	IDMemberCreator string           `json:"idMemberCreator"`
+	Date            time.Time        `json:"date"`
+	DateRead        time.Time        `json:"dataRead"`
+	Data            NotificationData `json:"data,omitempty"`
+	MemberCreator   *Member          `json:"memberCreator,omitempty"`
+}
+
+// NotificationData represents the 'notificaiton.data'
+type NotificationData struct {
+	Text  string                 `json:"text"`
+	Card  *NotificationDataCard  `json:"card,omitempty"`
+	Board *NotificationDataBoard `json:"board,omitempty"`
+}
+
+// NotificationDataBoard represents the 'notification.data.board'
+type NotificationDataBoard struct {
+	ID        string `json:"id"`
+	ShortLink string `json:"shortLink"`
+	Name      string `json:"name"`
+}
+
+// NotificationDataCard represents the 'notification.data.card'
+type NotificationDataCard struct {
+	ID        string `json:"id"`
+	IDShort   int    `json:"idShort"`
+	Name      string `json:"name"`
+	ShortLink string `json:"shortLink"`
+}
+
+// GetMyNotifications returns the notifications of the authenticated user
+func (c *Client) GetMyNotifications(args Arguments) (notifications []*Notification, err error) {
+	path := "members/me/notifications"
+	err = c.Get(path, args, &notifications)
+	for i := range notifications {
+		notifications[i].client = c
+	}
+	return
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -1,0 +1,25 @@
+package trello
+
+import "testing"
+
+func TestGetMyNotifications(t *testing.T) {
+	c := testClient()
+
+	c.BaseURL = mockResponse("notifications", "member-notifications-example.json").URL
+	notifications, err := c.GetMyNotifications(Defaults())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(notifications) != 2 {
+		t.Errorf("Expected 2 notifications. Got %d", len(notifications))
+	}
+
+	if notifications[0].Data.Board.Name != "Board Name" {
+		t.Errorf("Name of first notification incorrect. Got: '%s'", notifications[0].Data.Board.Name)
+	}
+
+	if notifications[1].Data.Board.Name != "Board Name 2" {
+		t.Errorf("Name of second notification incorrect. Got: '%s'", notifications[1].Data.Board.Name)
+	}
+}

--- a/testdata/notifications/member-notifications-example.json
+++ b/testdata/notifications/member-notifications-example.json
@@ -1,0 +1,70 @@
+[
+ {
+  "data": {
+   "board": {
+    "id": "54f1f121c22ec9ce1978b",
+    "name": "Board Name",
+    "shortLink": "UC0MD"
+   },
+   "card": {
+    "id": "5c70089c80b546edbf999",
+    "idShort": 8,
+    "name": "Card Name",
+    "shortLink": "bu4UD"
+   },
+   "text": "Text"
+  },
+  "date": "2010-02-22T15:57:51.474Z",
+  "dateRead": null,
+  "id": "5c702a1766214a57e6a16",
+  "idAction": "5c702a1764214a57e6a0a",
+  "idMemberCreator": "5ac32fdfc6a92698553b4",
+  "memberCreator": {
+   "avatarHash": "8e2a7a5417af80339294d528caab",
+   "avatarUrl": "https://trello-avatars.s3.amazonaws.com/8e2a7a541791adaf80394d528caab",
+   "fullName": "Name",
+   "id": "5ac32bf2f6a92698553b4",
+   "idMemberReferrer": "55671350dae9a310b69b0",
+   "initials": "B",
+   "nonPublic": {},
+   "username": "user_name"
+  },
+  "reactions": [],
+  "type": "commentCard",
+  "unread": true
+ },
+ {
+  "data": {
+   "board": {
+    "id": "54f1f121c22ec9ce1978b",
+    "name": "Board Name 2",
+    "shortLink": "UC0MD"
+   },
+   "card": {
+    "id": "5c70089c80b546edbf999",
+    "idShort": 8,
+    "name": "Card Name",
+    "shortLink": "bu4UD"
+   },
+   "text": "Text"
+  },
+  "date": "2010-02-22T15:57:51.474Z",
+  "dateRead": null,
+  "id": "5c702a1766214a57e6a16",
+  "idAction": "5c702a1764214a57e6a0a",
+  "idMemberCreator": "5ac32fdfc6a92698553b4",
+  "memberCreator": {
+   "avatarHash": "8e2a7a5417af80339294d528caab",
+   "avatarUrl": "https://trello-avatars.s3.amazonaws.com/8e2a7a541791adaf80394d528caab",
+   "fullName": "Name",
+   "id": "5ac32bf2f6a92698553b4",
+   "idMemberReferrer": "55671350dae9a310b69b0",
+   "initials": "B",
+   "nonPublic": {},
+   "username": "user_name"
+  },
+  "reactions": [],
+  "type": "commentCard",
+  "unread": true
+ }
+]


### PR DESCRIPTION
I needed to work with the Trello notifications and I've found that those where missing from this lib so I just added a basic implementation of the `GetMyNotifications`.

On my tests those are data that I could find that it returned, it could potentially need more data in side the `Data` field but I could not find it and it's not on the trello documentation.

To do this implementation I basically copied the `GetMyBoards` implementation and tests as it's basically the same usecase.

On the tests I've removed numbers from the IDs and changes sensible data from them too.