### PR TITLE
Revert "fix custom fields fetching #42"

### DIFF
--- a/card.go
+++ b/card.go
@@ -99,18 +99,41 @@ func (c *Card) CustomFields(boardCustomFields []*CustomField) map[string]interfa
 	if cfm == nil {
 		cfm = &(map[string]interface{}{})
 
-		// bcfNames[CustomFieldItem ID] = Custom Field Name
-		bcfNames := map[string]string{}
+		// bcfOptionNames[CustomField ID] = Custom Field Name
+		bcfOptionNames := map[string]string{}
+
+		// bcfOptionsMap[CustomField ID][ID of the option] = Value of the option
+		bcfOptionsMap := map[string]map[string]interface{}{}
 
 		for _, bcf := range boardCustomFields {
-			bcfNames[bcf.ID] = bcf.Name
-		}
+			bcfOptionNames[bcf.ID] = bcf.Name
+			for _, cf := range bcf.Options {
+				// create 2nd level map when not available yet
+				map2, ok := bcfOptionsMap[cf.IDCustomField]
+				if !ok {
+					map2 = map[string]interface{}{}
+					bcfOptionsMap[bcf.ID] = map2
+				}
 
-		for _, v := range c.CustomFieldItems {
-			if name, ok := bcfNames[v.IDCustomField]; ok {
-				(*cfm)[name] = v.Value.Get()
+				bcfOptionsMap[bcf.ID][cf.ID] = cf.Value.Text
 			}
 		}
+
+		for _, cf := range c.CustomFieldItems {
+			name := bcfOptionNames[cf.IDCustomField]
+
+			// create 2nd level map when not available yet
+			map2, ok := bcfOptionsMap[cf.IDCustomField]
+			if !ok {
+				continue
+			}
+			value, ok := map2[cf.IDValue]
+
+			if ok {
+				(*cfm)[name] = value
+			}
+		}
+		c.customFieldMap = cfm
 	}
 	return *cfm
 }

--- a/custom-fields.go
+++ b/custom-fields.go
@@ -1,108 +1,14 @@
 package trello
 
-import (
-	"database/sql/driver"
-	"encoding/json"
-	"fmt"
-	"strconv"
-	"time"
-)
+import "fmt"
 
 // CustomFieldItem represents the custom field items of Trello a trello card.
 type CustomFieldItem struct {
-	ID            string           `json:"id,omitempty"`
-	Value         CustomFieldValue `json:"value,omitempty"`
-	IDValue       string           `json:"idValue,omitempty"`
-	IDCustomField string           `json:"idCustomField,omitempty"`
-	IDModel       string           `json:"idModel,omitempty"`
-	IDModelType   string           `json:"modelType,omitempty"`
-}
-type CustomFieldValue struct {
-	val interface{}
-}
-type cfval struct {
-	Text    string `json:"text,omitempty"`
-	Number  string `json:"number,omitempty"`
-	Date    string `json:"date,omitempty"`
-	Checked string `json:"checked,omitempty"`
-}
-
-func NewCustomFieldValue(val interface{}) CustomFieldValue {
-	return CustomFieldValue{val: val}
-}
-
-const timeFmt = "2006-01-02T15:04:05Z"
-
-func (v CustomFieldValue) Get() interface{} {
-	return v.val
-}
-func (v CustomFieldValue) String() string {
-	return fmt.Sprintf("%s", v.val)
-}
-func (v CustomFieldValue) MarshalJSON() ([]byte, error) {
-	val := v.val
-
-	switchVal:
-	switch v := val.(type) {
-	case driver.Valuer:
-		var err error
-		val, err = v.Value()
-		if err != nil {
-			return nil, err
-		}
-		goto switchVal
-	case string:
-		return json.Marshal(cfval{Text: v})
-	case int, int64:
-		return json.Marshal(cfval{Number: fmt.Sprintf("%d", v)})
-	case float64:
-		return json.Marshal(cfval{Number: fmt.Sprintf("%f", v)})
-	case bool:
-		if v {
-			return json.Marshal(cfval{Checked: "true"})
-		} else {
-			return json.Marshal(cfval{Checked: "false"})
-		}
-	case time.Time:
-		return json.Marshal(cfval{Date: v.Format(timeFmt)})
-	default:
-		return nil, fmt.Errorf("unsupported type")
-	}
-}
-func (v *CustomFieldValue) UnmarshalJSON(b []byte) error {
-	cfval := cfval{}
-	err := json.Unmarshal(b, &cfval)
-	if err != nil {
-		return err
-	}
-	if cfval.Text != "" {
-		v.val = cfval.Text
-	}
-	if cfval.Date != "" {
-		v.val, err = time.Parse(timeFmt, cfval.Date)
-		if err != nil {
-			return err
-		}
-	}
-	if cfval.Checked != "" {
-		v.val = cfval.Checked == "true"
-	}
-	if cfval.Number != "" {
-		v.val, err = strconv.Atoi(cfval.Number)
-		if err != nil {
-			v.val, err = strconv.ParseFloat(cfval.Number, 64)
-			if err != nil {
-				v.val, err = strconv.ParseFloat(cfval.Number, 32)
-				if err != nil {
-					v.val, err = strconv.ParseInt(cfval.Number, 10, 64)
-					if err != nil {
-						return fmt.Errorf("cannot convert %s to number", cfval.Number)
-					}
-				}
-			}
-		}
-	}
-	return nil
+	ID            string `json:"id"`
+	IDValue       string `json:"idValue"`
+	IDCustomField string `json:"idCustomField"`
+	IDModel       string `json:"idModel"`
+	IDModelType   string `json:"modelType,omitempty"`
 }
 
 // CustomField represents Trello's custom fields: "extra bits of structured data


### PR DESCRIPTION
Reverts adlio/trello#43.

Oops... PR #43  broke support for dropdown custom fields, which don't include a `value` attribute. The earlier code only supported those kinds of fields, hence the confusion. Looks like we'll need a solution which addresses both.

Here's a [card](https://trello.com/c/hNfLpdVJ/16-card-with-custom-field-values) on a public board which has both types of fields.

## Relevant API Calls

https://trello.com/1/boards/QB4oHV5k/customFields
https://trello.com/1/cards/5cdc677dd4ee240932e119ca?customFieldItems=true
https://trello.com/1/boards/QB4oHV5k/cards?customFieldItems=true

## JSON Excerpt

The first item in the array below is a dropdown which corresponds to the choice `Chooser Option 2`. It doesn't include a `value` attribute... we have to extract it from the /boards/:id/customFields API call.

 ```
 "customFieldItems": [
    {
      "id": "5cdc678f79f3548c5ec2e371",
      "idValue": "5cdc6736f82ce051f2db8a82",
      "idCustomField": "5cdc672d83cbe31ba77ae615",
      "idModel": "5cdc677dd4ee240932e119ca",
      "modelType": "card"
    },
    {
      "id": "5cdc678db990c26c37f8ad6f",
      "value": {
        "checked": "true"
      },
      "idCustomField": "5cdc66c8833ecd0d7c4c3775",
      "idModel": "5cdc677dd4ee240932e119ca",
      "modelType": "card"
    },
    {
      "id": "5cdc678cccee0e2bab488863",
      "value": {
        "text": "This is a description of information."
      },
      "idCustomField": "5cdc66bf83867f4b7d7811be",
      "idModel": "5cdc677dd4ee240932e119ca",
      "modelType": "card"
    },
    {
      "id": "5cdc67858f1c98288d6479e2",
      "value": {
        "number": "57"
      },
      "idCustomField": "5cdc66b4807a523d8276b5d5",
      "idModel": "5cdc677dd4ee240932e119ca",
      "modelType": "card"
    }
  ],
```