### PR TITLE
fix: get rid of npe in search results

### DIFF
--- a/search.go
+++ b/search.go
@@ -1,6 +1,6 @@
 // Copyright © 2016 Aaron Longwell
 //
-// Use of this source code is governed by an MIT licese.
+// Use of this source code is governed by an MIT license.
 // Details in the LICENSE file.
 
 package trello
@@ -41,6 +41,9 @@ func (c *Client) SearchCards(query string, args Arguments) (cards []*Card, err e
 	res := SearchResult{}
 	err = c.Get("search", args, &res)
 	cards = res.Cards
+	for _, card := range cards {
+		card.client = c
+	}
 	return
 }
 

--- a/search_test.go
+++ b/search_test.go
@@ -19,6 +19,9 @@ func TestSearchCards(t *testing.T) {
 	if len(cards) != 1 {
 		t.Errorf("Expected 1 card search result. Got %d.", len(cards))
 	}
+	if cards[0].client == nil {
+		t.Errorf("Card struct in result has no client info")
+	}
 }
 
 func TestSearchBoards(t *testing.T) {


### PR DESCRIPTION
To avoid nil pointer in card structures
in search results add client to the results.

Add test.