### PR TITLE
feat: add custom field clean method

### DIFF
--- a/card.go
+++ b/card.go
@@ -123,8 +123,8 @@ func (c *Card) CustomFields(boardCustomFields []*CustomField) map[string]interfa
 
 		for _, cf := range c.CustomFieldItems {
 			if name, ok := bcfNames[cf.IDCustomField]; ok {
-				if cf.Value.Get() != nil {
-					(*cfm)[name] = cf.Value.Get()
+				if cf.Value != nil {
+					(*cfm)[name] = cf.Value
 				} else { // Dropbox
 					// create 2nd level map when not available yet
 					map2, ok := bcfOptionsMap[cf.IDCustomField]

--- a/card.go
+++ b/card.go
@@ -91,7 +91,6 @@ func (c *Card) CreatedAt() time.Time {
 	return t
 }
 
-
 // CustomFields returns the card's custom fields.
 func (c *Card) CustomFields(boardCustomFields []*CustomField) map[string]interface{} {
 
@@ -142,6 +141,19 @@ func (c *Card) CustomFields(boardCustomFields []*CustomField) map[string]interfa
 		}
 	}
 	return *cfm
+}
+
+// RemoveIDCustomField removes a custom field by ID from card
+func (c *Card) RemoveIDCustomField(customFieldID string, customFieldItem *CustomFieldItem) error {
+	path := fmt.Sprintf("cards/%s/customField/%s/item", c.ID, customFieldID)
+	return c.client.Put(
+		path,
+		Arguments{
+			"idValue": "",
+			"value":   "",
+		},
+		customFieldItem,
+	)
 }
 
 // MoveToList moves a card to a list given by listID.

--- a/card_test.go
+++ b/card_test.go
@@ -6,6 +6,7 @@
 package trello
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
@@ -69,14 +70,17 @@ func TestCardsCustomFields(t *testing.T) {
 	}
 
 	vf1, ok := fields["Field1"]
-	if !ok || vf1 != "F1 1st opt" {
-		t.Errorf("Expected Field1 to be 'F1 1st opt' but it was %v", vf1)
+	expected1 := &CustomFieldValue{Text: "F1 1st opt"}
+	if !ok || !reflect.DeepEqual(vf1, expected1) {
+		t.Errorf("\nExpected Field1:\n%#v\nbut it was:\n%#v", vf1, expected1)
 	}
 
 	vf2, ok := fields["Field2"]
-	if !ok || vf2 != "F2 2nd opt" {
-		t.Errorf("Expected Field1 to be 'F2 2nd opt' but it was %v", vf2)
+	expected2 := &CustomFieldValue{Text: "F2 2nd opt"}
+	if !ok || !reflect.DeepEqual(vf2.Text, expected2.Text) {
+		t.Errorf("\nExpected Field2:\n%#v\nbut it was:\n%#v", vf2, expected2)
 	}
+
 }
 
 func TestRemoveIDCustomField(t *testing.T) {

--- a/card_test.go
+++ b/card_test.go
@@ -82,13 +82,17 @@ func TestCardsCustomFields(t *testing.T) {
 func TestRemoveIDCustomField(t *testing.T) {
 	card := testCard(t)
 	card.client.BaseURL = mockResponse("customFields", "custom-fields-remove.json").URL
-	var customFieldItem CustomFieldItem
-	err := card.RemoveIDCustomField("customFieldDummyID", &customFieldItem)
+	customFieldItem := &CustomFieldItem{
+		Value: &CustomFieldValue{
+			Text: "Text that should be deleted",
+		},
+	}
+	err := card.RemoveIDCustomField("customFieldDummyID", customFieldItem)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if customFieldItem.Value.val != nil {
-		t.Fatal("Custom field value should be nil")
+	if customFieldItem.Value != nil {
+		t.Fatalf("Custom field value should be nil, but %+v", customFieldItem)
 	}
 }
 

--- a/card_test.go
+++ b/card_test.go
@@ -79,6 +79,19 @@ func TestCardsCustomFields(t *testing.T) {
 	}
 }
 
+func TestRemoveIDCustomField(t *testing.T) {
+	card := testCard(t)
+	card.client.BaseURL = mockResponse("customFields", "custom-fields-remove.json").URL
+	var customFieldItem CustomFieldItem
+	err := card.RemoveIDCustomField("customFieldDummyID", &customFieldItem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if customFieldItem.Value.val != nil {
+		t.Fatal("Custom field value should be nil")
+	}
+}
+
 func TestBoardContainsCopyOfCard(t *testing.T) {
 	board := testBoard(t)
 	board.client.BaseURL = mockResponse("actions", "board-actions-copyCard.json").URL
@@ -232,7 +245,7 @@ func TestAddURLAttachmentToCard(t *testing.T) {
 	c.client.BaseURL = mockResponse("cards", "url-attachments.json").URL
 	attachment := Attachment{
 		Name: "Test",
-		URL: "https://github.com/test",
+		URL:  "https://github.com/test",
 	}
 	err := c.AddURLAttachment(&attachment)
 	if err != nil {

--- a/custom-fields.go
+++ b/custom-fields.go
@@ -1,108 +1,25 @@
 package trello
 
 import (
-	"database/sql/driver"
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"time"
 )
 
 // CustomFieldItem represents the custom field items of Trello a trello card.
 type CustomFieldItem struct {
-	ID            string           `json:"id,omitempty"`
-	Value         CustomFieldValue `json:"value,omitempty"`
-	IDValue       string           `json:"idValue,omitempty"`
-	IDCustomField string           `json:"idCustomField,omitempty"`
-	IDModel       string           `json:"idModel,omitempty"`
-	IDModelType   string           `json:"modelType,omitempty"`
+	ID            string            `json:"id,omitempty"`
+	Value         *CustomFieldValue `json:"value,omitempty"`
+	IDValue       string            `json:"idValue,omitempty"`
+	IDCustomField string            `json:"idCustomField,omitempty"`
+	IDModel       string            `json:"idModel,omitempty"`
+	IDModelType   string            `json:"modelType,omitempty"`
 }
+
+// CustomFieldValue represents value of the custom field
 type CustomFieldValue struct {
-	val interface{}
-}
-type cfval struct {
 	Text    string `json:"text,omitempty"`
 	Number  string `json:"number,omitempty"`
 	Date    string `json:"date,omitempty"`
 	Checked string `json:"checked,omitempty"`
-}
-
-func NewCustomFieldValue(val interface{}) CustomFieldValue {
-	return CustomFieldValue{val: val}
-}
-
-const timeFmt = "2006-01-02T15:04:05Z"
-
-func (v CustomFieldValue) Get() interface{} {
-	return v.val
-}
-func (v CustomFieldValue) String() string {
-	return fmt.Sprintf("%s", v.val)
-}
-func (v CustomFieldValue) MarshalJSON() ([]byte, error) {
-	val := v.val
-
-	switchVal:
-	switch v := val.(type) {
-	case driver.Valuer:
-		var err error
-		val, err = v.Value()
-		if err != nil {
-			return nil, err
-		}
-		goto switchVal
-	case string:
-		return json.Marshal(cfval{Text: v})
-	case int, int64:
-		return json.Marshal(cfval{Number: fmt.Sprintf("%d", v)})
-	case float64:
-		return json.Marshal(cfval{Number: fmt.Sprintf("%f", v)})
-	case bool:
-		if v {
-			return json.Marshal(cfval{Checked: "true"})
-		} else {
-			return json.Marshal(cfval{Checked: "false"})
-		}
-	case time.Time:
-		return json.Marshal(cfval{Date: v.Format(timeFmt)})
-	default:
-		return nil, fmt.Errorf("unsupported type")
-	}
-}
-func (v *CustomFieldValue) UnmarshalJSON(b []byte) error {
-	cfval := cfval{}
-	err := json.Unmarshal(b, &cfval)
-	if err != nil {
-		return err
-	}
-	if cfval.Text != "" {
-		v.val = cfval.Text
-	}
-	if cfval.Date != "" {
-		v.val, err = time.Parse(timeFmt, cfval.Date)
-		if err != nil {
-			return err
-		}
-	}
-	if cfval.Checked != "" {
-		v.val = cfval.Checked == "true"
-	}
-	if cfval.Number != "" {
-		v.val, err = strconv.Atoi(cfval.Number)
-		if err != nil {
-			v.val, err = strconv.ParseFloat(cfval.Number, 64)
-			if err != nil {
-				v.val, err = strconv.ParseFloat(cfval.Number, 32)
-				if err != nil {
-					v.val, err = strconv.ParseInt(cfval.Number, 10, 64)
-					if err != nil {
-						return fmt.Errorf("cannot convert %s to number", cfval.Number)
-					}
-				}
-			}
-		}
-	}
-	return nil
 }
 
 // CustomField represents Trello's custom fields: "extra bits of structured data

--- a/testdata/customFields/custom-fields-remove.json
+++ b/testdata/customFields/custom-fields-remove.json
@@ -1,0 +1,7 @@
+{
+    "id": "dummyID",
+    "value": null,
+    "idCustomField": "customFieldDummyID",
+    "idModel": "dummyIDModel",
+    "modelType": "card"
+}


### PR DESCRIPTION
### This PR has three commits that need the review.

#### `feat: add RemoveIDCustomField method`
In this commit I've added the method to delete (only clear) custom field of the card by its ID (see "Clearing CustomFieldItems" [here](https://developer.atlassian.com/cloud/trello/guides/rest-api/getting-started-with-custom-fields/)).

But there was a problem. Because of the definition of the `Value` field in the `CustomFieldItem` result from the API was not parsed correctly.
I'd tried to understand why we need here (in general purpose library) so complex unmarshaling with some kind of the business logic and stuck with that. There are no tests to explain this.

#### `impr: change custom fields value struct`
To develop this idea I've simplified `CustomFieldItem` struct and all corresponding methods. No tests was broken after that, only type actualization. 

#### `impr: refactor CustomFields method`
As a result I've refactor `CustomFields` card method to use more idiomatic go code and new simplified `CustomFieldItem` struct.

#### Conclusion
I think, that it is more correct style for the general library and type casting from the `CustomFieldItemValue` should be done in the business logic on the application level. The casting logic that was here earlier is hard to understand and did not have general application.