### PR TITLE
Add functions to archive & unarchive a card

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,15 @@ A board can be created or deleted on the `Board` struct for the user whose crede
   }
 ```
 
+## Archiving & Unarchiving a Card
+```Go
+// archive
+err := card.Archive("cArDID")
+
+// unarchive
+err := card.Unarchive("cArDID")
+```
+
 ## Creating a Card
 
 The API provides several mechanisms for creating new cards.

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,3 @@
 - Create List
 - Delete Card
-- Archive Card
 - Reorder Cards in List
-

--- a/card.go
+++ b/card.go
@@ -202,6 +202,16 @@ func (c *Card) Update(args Arguments) error {
 	return c.client.Put(path, args, c)
 }
 
+// Archive Archives the card.
+func (c *Card) Archive() error {
+	return c.Update(Arguments{"closed": "true"})
+}
+
+// Unarchive Unarchives the card.
+func (c *Card) Unarchive() error {
+	return c.Update(Arguments{"closed": "false"})
+}
+
 // CreateCard takes a Card and Arguments and POSTs the card.
 func (c *Client) CreateCard(card *Card, extraArgs Arguments) error {
 	path := "cards"

--- a/card_test.go
+++ b/card_test.go
@@ -168,6 +168,20 @@ func TestAddCardToList(t *testing.T) {
 	}
 }
 
+func TestArchiveUnarchive(t *testing.T) {
+	c := testCard(t)
+	c.Archive()
+
+	if c.Closed == false {
+		t.Errorf("Card should have been archived.")
+	}
+
+	c.Unarchive()
+	if c.Closed == true {
+		t.Errorf("Card should have been unarchived.")
+	}
+}
+
 func TestCopyCardToList(t *testing.T) {
 	c := testCard(t)
 	c.client.BaseURL = mockResponse("cards", "card-copied.json").URL
@@ -232,7 +246,7 @@ func TestAddURLAttachmentToCard(t *testing.T) {
 	c.client.BaseURL = mockResponse("cards", "url-attachments.json").URL
 	attachment := Attachment{
 		Name: "Test",
-		URL: "https://github.com/test",
+		URL:  "https://github.com/test",
 	}
 	err := c.AddURLAttachment(&attachment)
 	if err != nil {


### PR DESCRIPTION
This PR adds shorthands for archiving and unarchiving a card. 

Even though both actions can be done using the existing `Update` method, having explicit methods for these actions would increase the ease of use IMHO. 

Also, it was one of the items in `TODO.txt`