### PR TITLE
Use rate.Limiter for throttling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/adlio/trello
 
 go 1.12
 
-require github.com/pkg/errors v0.8.1
+require (
+	github.com/pkg/errors v0.8.1
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
from my manual testing, this will no longer cause high CPU usage (as
reported in #72).

I wasn't sure how to properly test the throttling, but looking at the documentation of the rate package this should do.

I used this for testing:

```go
package main

import (
	"log"
	"time"

	"github.com/Rukenshia/trello"
)

func main() {
	for {
		log.Printf("Creating 100 new clients")
		for i := 0; i < 100; i++ {
			client := trello.NewClient("foo", "bar")

			log.Printf("client: %v", client)
		}
		time.Sleep(5 * time.Second)
	}
}
```

before this change, CPU usage went up with every 5 second iteration. After the change, the CPU usage is consistently at 0%.