### PR TITLE
feat: support `Archive` and `Unarchive` methods on `List`

### DIFF
--- a/list.go
+++ b/list.go
@@ -106,3 +106,13 @@ func (l *List) Update(extraArgs ...Arguments) error {
 	path := fmt.Sprintf("lists/%s", l.ID)
 	return l.client.Put(path, args, l)
 }
+
+// Archive archives the list.
+func (l *List) Archive() error {
+	return l.Update(Arguments{"closed": "true"})
+}
+
+// Unarchive unarchives the list.
+func (l *List) Unarchive() error {
+	return l.Update(Arguments{"closed": "false"})
+}

--- a/list_test.go
+++ b/list_test.go
@@ -174,6 +174,26 @@ func TestUpdateList(t *testing.T) {
 	}
 }
 
+func TestArchiveUnarchiveList(t *testing.T) {
+	l := testList(t)
+
+	server := mockResponse("lists", "list-archived.json")
+	l.client.BaseURL = server.URL
+	l.Archive()
+	if l.Closed == false {
+		t.Errorf("List should have been archived.")
+	}
+	server.Close()
+
+	server = mockResponse("lists", "list-unarchived.json")
+	l.client.BaseURL = server.URL
+	l.Unarchive()
+	if l.Closed == true {
+		t.Errorf("List should have been unarchived.")
+	}
+	server.Close()
+}
+
 func TestListSetClient(t *testing.T) {
 	list := List{}
 	client := testClient()

--- a/testdata/lists/list-archived.json
+++ b/testdata/lists/list-archived.json
@@ -1,0 +1,7 @@
+{
+  "id": "5ccd793e91682684235c0b13",
+  "name": "list-name",
+  "closed": true,
+  "idBoard": "5d31c3d8615ae32928635a28",
+  "pos": 24576
+}

--- a/testdata/lists/list-unarchived.json
+++ b/testdata/lists/list-unarchived.json
@@ -1,0 +1,7 @@
+{
+  "id": "5ccd793e91682684235c0b13",
+  "name": "list-name",
+  "closed": false,
+  "idBoard": "5d31c3d8615ae32928635a28",
+  "pos": 24576
+}


### PR DESCRIPTION
Adds the ability to archive and unarchive lists in the same manner as with cards.

Trello does actually provide a `list/{id}/closed` endpoint you can `PUT` to with `value: true | false`, but using `Update` is a bit smaller codewise and there doesn't seem to be any downside, so I went with that :)