### PR TITLE
Extracted field structs to named structs for ease of use in empty struct checks

### DIFF
--- a/board.go
+++ b/board.go
@@ -10,55 +10,59 @@ import (
 	"time"
 )
 
+type BoardPrefs struct {
+	PermissionLevel       string            `json:"permissionLevel"`
+	Voting                string            `json:"voting"`
+	Comments              string            `json:"comments"`
+	Invitations           string            `json:"invitations"`
+	SelfJoin              bool              `json:"selfjoin"`
+	CardCovers            bool              `json:"cardCovers"`
+	CardAging             string            `json:"cardAging"`
+	CalendarFeedEnabled   bool              `json:"calendarFeedEnabled"`
+	Background            string            `json:"background"`
+	BackgroundColor       string            `json:"backgroundColor"`
+	BackgroundImage       string            `json:"backgroundImage"`
+	BackgroundImageScaled []BackgroundImage `json:"backgroundImageScaled"`
+	BackgroundTile        bool              `json:"backgroundTile"`
+	BackgroundBrightness  string            `json:"backgroundBrightness"`
+	CanBePublic           bool              `json:"canBePublic"`
+	CanBeOrg              bool              `json:"canBeOrg"`
+	CanBePrivate          bool              `json:"canBePrivate"`
+	CanInvite             bool              `json:"canInvite"`
+}
+
+type BoardLabelNames struct {
+	Black  string `json:"black,omitempty"`
+	Blue   string `json:"blue,omitempty"`
+	Green  string `json:"green,omitempty"`
+	Lime   string `json:"lime,omitempty"`
+	Orange string `json:"orange,omitempty"`
+	Pink   string `json:"pink,omitempty"`
+	Purple string `json:"purple,omitempty"`
+	Red    string `json:"red,omitempty"`
+	Sky    string `json:"sky,omitempty"`
+	Yellow string `json:"yellow,omitempty"`
+}
+
 // Board represents a Trello Board.
 // https://developers.trello.com/reference/#boardsid
 type Board struct {
 	client         *Client
-	ID             string `json:"id"`
-	Name           string `json:"name"`
-	Desc           string `json:"desc"`
-	Closed         bool   `json:"closed"`
-	IDOrganization string `json:"idOrganization"`
-	Pinned         bool   `json:"pinned"`
-	Starred        bool   `json:"starred"`
-	URL            string `json:"url"`
-	ShortURL       string `json:"shortUrl"`
-	Prefs          struct {
-		PermissionLevel       string            `json:"permissionLevel"`
-		Voting                string            `json:"voting"`
-		Comments              string            `json:"comments"`
-		Invitations           string            `json:"invitations"`
-		SelfJoin              bool              `json:"selfjoin"`
-		CardCovers            bool              `json:"cardCovers"`
-		CardAging             string            `json:"cardAging"`
-		CalendarFeedEnabled   bool              `json:"calendarFeedEnabled"`
-		Background            string            `json:"background"`
-		BackgroundColor       string            `json:"backgroundColor"`
-		BackgroundImage       string            `json:"backgroundImage"`
-		BackgroundImageScaled []BackgroundImage `json:"backgroundImageScaled"`
-		BackgroundTile        bool              `json:"backgroundTile"`
-		BackgroundBrightness  string            `json:"backgroundBrightness"`
-		CanBePublic           bool              `json:"canBePublic"`
-		CanBeOrg              bool              `json:"canBeOrg"`
-		CanBePrivate          bool              `json:"canBePrivate"`
-		CanInvite             bool              `json:"canInvite"`
-	} `json:"prefs"`
-	Subscribed bool `json:"subscribed"`
-	LabelNames struct {
-		Black  string `json:"black,omitempty"`
-		Blue   string `json:"blue,omitempty"`
-		Green  string `json:"green,omitempty"`
-		Lime   string `json:"lime,omitempty"`
-		Orange string `json:"orange,omitempty"`
-		Pink   string `json:"pink,omitempty"`
-		Purple string `json:"purple,omitempty"`
-		Red    string `json:"red,omitempty"`
-		Sky    string `json:"sky,omitempty"`
-		Yellow string `json:"yellow,omitempty"`
-	} `json:"labelNames"`
-	Lists        []*List      `json:"lists"`
-	Actions      []*Action    `json:"actions"`
-	Organization Organization `json:"organization"`
+	ID             string          `json:"id"`
+	Name           string          `json:"name"`
+	Desc           string          `json:"desc"`
+	Closed         bool            `json:"closed"`
+	IDOrganization string          `json:"idOrganization"`
+	Pinned         bool            `json:"pinned"`
+	Starred        bool            `json:"starred"`
+	URL            string          `json:"url"`
+	ShortURL       string          `json:"shortUrl"`
+	Prefs          BoardPrefs      `json:"prefs"`
+	Subscribed     bool            `json:"subscribed"`
+	LabelNames     BoardLabelNames `json:"labelNames"`
+	Lists          []*List         `json:"lists"`
+	Actions        []*Action       `json:"actions"`
+	Organization   Organization    `json:"organization"`
 }
 
 // NewBoard is a constructor that sets the default values

--- a/card.go
+++ b/card.go
@@ -14,6 +14,19 @@ import (
 	"github.com/pkg/errors"
 )
 
+type CardBadges struct {
+	Votes              int        `json:"votes"`
+	ViewingMemberVoted bool       `json:"viewingMemberVoted"`
+	Subscribed         bool       `json:"subscribed"`
+	Fogbugz            string     `json:"fogbugz,omitempty"`
+	CheckItems         int        `json:"checkItems"`
+	CheckItemsChecked  int        `json:"checkItemsChecked"`
+	Comments           int        `json:"comments"`
+	Attachments        int        `json:"attachments"`
+	Description        bool       `json:"description"`
+	Due                *time.Time `json:"due,omitempty"`
+}
+
 // Card represents the card resource.
 // https://developers.trello.com/reference/#card-object
 type Card struct {
@@ -44,18 +57,7 @@ type Card struct {
 	IDList string `json:"idList"`
 
 	// Badges
-	Badges struct {
-		Votes              int        `json:"votes"`
-		ViewingMemberVoted bool       `json:"viewingMemberVoted"`
-		Subscribed         bool       `json:"subscribed"`
-		Fogbugz            string     `json:"fogbugz,omitempty"`
-		CheckItems         int        `json:"checkItems"`
-		CheckItemsChecked  int        `json:"checkItemsChecked"`
-		Comments           int        `json:"comments"`
-		Attachments        int        `json:"attachments"`
-		Description        bool       `json:"description"`
-		Due                *time.Time `json:"due,omitempty"`
-	} `json:"badges"`
+	Badges CardBadges `json:"badges"`
 
 	// Actions
 	Actions ActionCollection `json:"actions,omitempty"`


### PR DESCRIPTION
I extracted the structs that were inline in board.go and card.go into their own exported (named) structs. This should make it easier to check if they are empty by allowing checks such as this: 
```go
// Where board is an initialized Board
if board.Prefs == BoardPrefs{} {
// This is empty
} else {
// There are prefs here
}
```