### PR TITLE
Rukenshia/trello Merge

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,2 +1,0 @@
-- Create List
-- Reorder Cards in List

--- a/card_test.go
+++ b/card_test.go
@@ -6,7 +6,6 @@
 package trello
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -27,10 +26,10 @@ func TestCardCreatedAt(t *testing.T) {
 func TestGetCardsOnBoard(t *testing.T) {
 	board := testBoard(t)
 
-	server := mockDynamicPathResponse()
+	server := NewMockResponder(t)
 	defer server.Close()
 
-	board.client.BaseURL = server.URL
+	board.client.BaseURL = server.URL()
 	cards, err := board.GetCards(Defaults())
 	if err != nil {
 		t.Fatal(err)
@@ -43,9 +42,9 @@ func TestGetCardsOnBoard(t *testing.T) {
 func TestGetCardsInList(t *testing.T) {
 	list := testList(t)
 
-	server := mockResponse("cards", "list-cards-api-example.json")
+	server := NewMockResponder(t, "cards", "list-cards-api-example.json")
 	defer server.Close()
-	list.client.BaseURL = server.URL
+	list.client.BaseURL = server.URL()
 
 	cards, err := list.GetCards(Defaults())
 	if err != nil {
@@ -59,9 +58,9 @@ func TestGetCardsInList(t *testing.T) {
 func TestCardsCustomFields(t *testing.T) {
 	list := testList(t)
 
-	server := mockResponse("cards", "list-cards-api-example.json")
+	server := NewMockResponder(t, "cards", "list-cards-api-example.json")
 	defer server.Close()
-	list.client.BaseURL = server.URL
+	list.client.BaseURL = server.URL()
 
 	cards, err := list.GetCards(Defaults())
 	if err != nil {
@@ -96,10 +95,10 @@ func TestCardsCustomFields(t *testing.T) {
 func TestBoardContainsCopyOfCard(t *testing.T) {
 	board := testBoard(t)
 
-	server := mockResponse("actions", "board-actions-copyCard.json")
+	server := NewMockResponder(t, "actions", "board-actions-copyCard.json")
 	defer server.Close()
 
-	board.client.BaseURL = server.URL
+	board.client.BaseURL = server.URL()
 	firstResult, err := board.ContainsCopyOfCard("57f50c552b96e3fffe588aad", Defaults())
 	if err != nil {
 		t.Error(err)
@@ -221,16 +220,16 @@ func TestAddCardToList(t *testing.T) {
 func TestArchiveUnarchive(t *testing.T) {
 	c := testCard(t)
 
-	server := mockResponse("cards", "card-archived.json")
-	c.client.BaseURL = server.URL
+	server := NewMockResponder(t, "cards", "card-archived.json")
+	c.client.BaseURL = server.URL()
 	c.Archive()
 	if c.Closed == false {
 		t.Errorf("Card should have been archived.")
 	}
 	server.Close()
 
-	server = mockResponse("cards", "card-unarchived.json")
-	c.client.BaseURL = server.URL
+	server = NewMockResponder(t, "cards", "card-unarchived.json")
+	c.client.BaseURL = server.URL()
 	c.Unarchive()
 	if c.Closed == true {
 		t.Errorf("Card should have been unarchived.")
@@ -241,9 +240,9 @@ func TestArchiveUnarchive(t *testing.T) {
 func TestCopyCardToList(t *testing.T) {
 	c := testCard(t)
 
-	server := mockResponse("cards", "card-copied.json")
+	server := NewMockResponder(t, "cards", "card-copied.json")
 	defer server.Close()
-	c.client.BaseURL = server.URL
+	c.client.BaseURL = server.URL()
 
 	newCard, err := c.CopyToList("57f03a022cd45c863ca581f1", Defaults())
 	if err != nil {
@@ -262,9 +261,9 @@ func TestCopyCardToList(t *testing.T) {
 func TestGetParentCard(t *testing.T) {
 	c := testCard(t)
 
-	server := mockDynamicPathResponse()
+	server := NewMockResponder(t)
 	defer server.Close()
-	c.client.BaseURL = server.URL
+	c.client.BaseURL = server.URL()
 
 	parent, err := c.GetParentCard(Defaults())
 	if err != nil {
@@ -293,10 +292,10 @@ func TestGetAncestorCards(t *testing.T) {
 
 func TestAddMemberIdToCard(t *testing.T) {
 	c := testCard(t)
-	server := mockResponse("cards", "card-add-member-response.json")
+	server := NewMockResponder(t, "cards", "card-add-member-response.json")
 	defer server.Close()
 
-	c.client.BaseURL = server.URL
+	c.client.BaseURL = server.URL()
 	member, err := c.AddMemberID("testmemberid")
 	if err != nil {
 		t.Error(err)
@@ -311,10 +310,10 @@ func TestAddMemberIdToCard(t *testing.T) {
 
 func TestAddURLAttachmentToCard(t *testing.T) {
 	c := testCard(t)
-	server := mockResponse("cards", "url-attachments.json")
+	server := NewMockResponder(t, "cards", "url-attachments.json")
 	defer server.Close()
 
-	c.client.BaseURL = server.URL
+	c.client.BaseURL = server.URL()
 	attachment := Attachment{
 		Name: "Test",
 		URL:  "https://github.com/test",
@@ -341,10 +340,10 @@ func TestCardSetClient(t *testing.T) {
 //
 func testCard(t *testing.T) *Card {
 	c := testClient()
-	server := mockResponse("cards", "card-api-example.json")
+	server := NewMockResponder(t, "cards", "card-api-example.json")
 	defer server.Close()
 
-	c.BaseURL = server.URL
+	c.BaseURL = server.URL()
 	card, err := c.GetCard("4eea503", Defaults())
 	if err != nil {
 		t.Fatal(err)

--- a/card_test.go
+++ b/card_test.go
@@ -119,23 +119,21 @@ func TestBoardContainsCopyOfCard(t *testing.T) {
 
 func TestCreateCard(t *testing.T) {
 	c := testClient()
-	server := mockResponseWithRequestValidator(t, func(r *http.Request) error {
+	server := NewMockResponder(t, "cards", "card-create.json")
+	defer server.Close()
+	server.AssertRequest(func(t *testing.T, r *http.Request) {
 		due := r.URL.Query().Get("due")
-
 		if _, err := time.Parse(time.RFC3339, due); err != nil {
-			return fmt.Errorf("Expected due to be in RFC3339 format, but value was '%v'", due)
+			t.Errorf("Expected due to be in RFC3339 format, but value was '%v'", due)
 		}
 
 		start := r.URL.Query().Get("start")
-
 		if _, err := time.Parse(time.RFC3339, start); err != nil {
-			return fmt.Errorf("Expected start to be in RFC3339 format, but value was '%v'", start)
+			t.Errorf("Expected start to be in RFC3339 format, but value was '%v'", start)
 		}
-		return nil
-	}, "cards", "card-create.json")
-	defer server.Close()
+	})
 
-	c.BaseURL = server.URL
+	c.BaseURL = server.URL()
 	dueDate := time.Now().AddDate(0, 0, 3)
 	startDate := time.Now().AddDate(0, 0, 2)
 
@@ -173,22 +171,20 @@ func TestCreateCard(t *testing.T) {
 func TestAddCardToList(t *testing.T) {
 	l := testList(t)
 
-	server := mockResponseWithRequestValidator(t, func(r *http.Request) error {
+	server := NewMockResponder(t, "cards", "card-posted-to-bottom-of-list.json")
+	server.AssertRequest(func(t *testing.T, r *http.Request) {
 		due := r.URL.Query().Get("due")
-
 		if _, err := time.Parse(time.RFC3339, due); err != nil {
-			return fmt.Errorf("Expected due to be in RFC3339 format, but value was '%v'", due)
+			t.Errorf("Expected due to be in RFC3339 format, but value was '%v'", due)
 		}
 
 		start := r.URL.Query().Get("start")
-
 		if _, err := time.Parse(time.RFC3339, start); err != nil {
-			return fmt.Errorf("Expected start to be in RFC3339 format, but value was '%v'", start)
+			t.Errorf("Expected start to be in RFC3339 format, but value was '%v'", start)
 		}
-		return nil
-	}, "cards", "card-posted-to-bottom-of-list.json")
+	})
 	defer server.Close()
-	l.client.BaseURL = server.URL
+	l.client.BaseURL = server.URL()
 	dueDate := time.Now().AddDate(0, 0, 2)
 	startDate := time.Now().AddDate(0, 0, 1)
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Rukenshia/trello
+module github.com/adlio/trello
 
 go 1.13
 

--- a/mock-responder_test.go
+++ b/mock-responder_test.go
@@ -1,0 +1,153 @@
+package trello
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// MockResponder is a thin wrapper around the httptest.Server. It adds the
+// ability to specify a file or directory of files to use as mock responses,
+// and provides the AsertRequest method to add test assertions that requests
+// are being made correctly. Just like with httptest.Server, the caller should
+// defer a call to .Close() to shutdown the server when all requests complete.
+// MockResponders should be created via the NewMockResponder() constructor.
+//
+type MockResponder interface {
+	Close()
+	URL() string
+	AssertRequest(func(t *testing.T, r *http.Request))
+}
+
+type mockResponder struct {
+	t *testing.T
+
+	// server will be nil until .URL() is called the first time
+	server *httptest.Server
+
+	// requestAssertions is a list of functions which is called on
+	// each HTTP request before finding and returning the mock response content.
+	// They should be used to make assertions on the contents of the HTTP
+	// request being made against this MockResponder
+	requestAssertions []func(t *testing.T, r *http.Request)
+
+	// mockPath holds the results of filepath.Join on the provided path parts.
+	// The constructor verifies the existence of the path, so this will always
+	// hold a valid path to either a mock file, or a directory of many mocks
+	mockPath string
+
+	// useDynamicPaths is set to true when mockPath is a directory. It triggers
+	// code which determies the mock file from the path of incoming HTTP
+	// requests
+	useDynamicPaths bool
+}
+
+// NewMockResponder creates a new MockResponder instance around the provided
+// test case. The mockPath is the relative filesystem path under ./testdata/
+// where the mock response JSON can be found.
+//
+// If mockPath describes the path to a *file*, then that file
+// will be used for ALL requests. If the path is a directory, then the mock
+// response will be built dynamically from the path of the request (e.g.
+// GET /subdir/folder/file will return the file at subdir/folder/file.json,
+// assuming it exists). This latter mode is described as "dynamic paths". When
+// requests arrive with querystring arguments, the dynamic path builder will
+// compute an MD5 hash of the arguments and include that as a suffix of the
+// mock file path.
+//
+// If no mockPath is provided, then the MockResponder will run in dynamic path
+// mode from the root of the testdata/ directory.
+//
+// The caller is expected to defer a call .Close() after NewMockResponder().
+//
+func NewMockResponder(t *testing.T, mockPath ...string) MockResponder {
+	r := &mockResponder{t: t}
+
+	// Verify a valid path was provided
+	r.mockPath = filepath.Join(append([]string{".", "testdata"}, mockPath...)...)
+	fi, err := os.Stat(r.mockPath)
+	if err != nil {
+		log.Fatalf("invalid mock path %v: %s", mockPath, err)
+	}
+
+	// If the provided mockPath points to a directory, then
+	// we'll figure out the ultimate path dynamically as requests occur.
+	r.useDynamicPaths = fi.IsDir()
+
+	return r
+}
+
+// AssertRequest adds a new function to be run on each HTTP request the mock
+// responder recveives. Its intended use is to make test assertions on the
+// content of the request
+func (mr *mockResponder) AssertRequest(ra func(t *testing.T, r *http.Request)) {
+	mr.requestAssertions = append(mr.requestAssertions, ra)
+}
+
+// Close wraps the *httptest.Server's Close method
+func (mr *mockResponder) Close() {
+	if mr.server != nil {
+		mr.server.Close()
+	}
+}
+
+// URL is equivalent to the *httptest.Server property of the same name, but it
+// is responsible for *creating* the *httptest.Server. This function should
+// be called after all customization (including calls to AssertRequest) is
+// complete.
+//
+func (mr *mockResponder) URL() string {
+	if mr.server != nil {
+		mr.t.Error("URL() should only be called once, after completing configuration")
+	}
+	mr.server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		for _, assertion := range mr.requestAssertions {
+			assertion(mr.t, r)
+		}
+		mr.mockHandler(rw, r)
+	}))
+	return mr.server.URL
+}
+
+// mockHandler is the http.HandlerFunc for the httptest.Server inside the
+// mockResponder. When the mockPath points to a single file, it simply returns
+// that file in the HTTP response. Otherwise it dynamically determines the
+// path of the mock file to use and returns that if the file is found...
+// otherwise it responds with an error instructing the user where to put their
+// mock file.
+//
+func (mr *mockResponder) mockHandler(rw http.ResponseWriter, r *http.Request) {
+	var filename string
+	if mr.useDynamicPaths {
+		parts := []string{mr.mockPath}
+		parts = append(parts, strings.Split(strings.TrimPrefix(r.URL.Path, "/"), "/")...)
+		queryStringPart := strings.Replace(r.URL.RawQuery, "key=user&token=pass", "", -1)
+		if queryStringPart != "" {
+			parts[len(parts)-1] = fmt.Sprintf("%s-%x", parts[len(parts)-1], md5.Sum([]byte(queryStringPart)))
+		}
+
+		filename = filepath.Join(parts...)
+		if !strings.HasSuffix(filename, ".json") {
+			filename = filename + ".json"
+		}
+		if _, err := os.Stat(filename); err != nil {
+			http.Error(rw, fmt.Sprintf("%s doesn't exist or couldn't be read. Create it with the mock you'd like to use.\n Args were: %s", filename, queryStringPart), http.StatusNotFound)
+			return
+		}
+	} else {
+		filename = mr.mockPath
+	}
+
+	mockData, err := ioutil.ReadFile(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	rw.Write(mockData)
+}

--- a/mock-response_test.go
+++ b/mock-response_test.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 )
 
 func mockResponse(paths ...string) *httptest.Server {
@@ -27,25 +26,6 @@ func mockResponse(paths ...string) *httptest.Server {
 		log.Fatal(err)
 	}
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		rw.Write(mockData)
-	}))
-}
-
-func mockResponseWithRequestValidator(t *testing.T, validatorFn func(r *http.Request) error, paths ...string) *httptest.Server {
-	parts := []string{".", "testdata"}
-	filename := filepath.Join(append(parts, paths...)...)
-
-	mockData, err := ioutil.ReadFile(filename)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if err := validatorFn(r); err != nil {
-			t.Errorf("Request validation failed: %v", err)
-			t.FailNow()
-			return
-		}
-
 		rw.Write(mockData)
 	}))
 }


### PR DESCRIPTION
This PR includes PR #88 (adding the `Start` field to Card) as well as the Client.Cleanup() method for cleaning up the rate limiting ticker (from Rukenshia/trello).

It also introduces a new method for testing mocks that allows request assertions (see: `MockResponder`)