### PR TITLE
fix: change products and powerups type in organization struct

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -13,14 +13,14 @@ import (
 // https://developers.trello.com/reference/#organizations
 type Organization struct {
 	client      *Client
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	DisplayName string   `json:"displayName"`
-	Desc        string   `json:"desc"`
-	URL         string   `json:"url"`
-	Website     string   `json:"website"`
-	Products    []string `json:"products"`
-	PowerUps    []string `json:"powerUps"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Desc        string `json:"desc"`
+	URL         string `json:"url"`
+	Website     string `json:"website"`
+	Products    []int  `json:"products"`
+	PowerUps    []int  `json:"powerUps"`
 }
 
 // GetOrganization takes an organization id and Arguments and either

--- a/organization_test.go
+++ b/organization_test.go
@@ -14,6 +14,18 @@ func TestGetOrganization(t *testing.T) {
 	if organization.DisplayName != "Culture Foundry" {
 		t.Errorf("Expected name 'Culture Foundry'. Got '%s'.", organization.DisplayName)
 	}
+	if len(organization.PowerUps) != 1 {
+		t.Errorf("Expected PowerUps to have length of 1 but was %d", len(organization.PowerUps))
+	}
+	if organization.PowerUps[0] != 42 {
+		t.Errorf("Expected first PowerUp to be %d but was %d", 42, organization.PowerUps[0])
+	}
+	if len(organization.Products) != 1 {
+		t.Errorf("Expected Products to have length of 1 but was %d", len(organization.Products))
+	}
+	if organization.Products[0] != 110 {
+		t.Errorf("Expected first Product to be %d but was %d", 110, organization.Products[0])
+	}
 }
 
 func TestGetBoardsInOrganization(t *testing.T) {

--- a/testdata/organizations/culturefoundry.json
+++ b/testdata/organizations/culturefoundry.json
@@ -7,6 +7,6 @@
   "url": "https://trello.com/culturefoundry",
   "website": null,
   "logoHash": null,
-  "products": [],
-  "powerUps": []
+  "products": [110],
+  "powerUps": [42]
 }


### PR DESCRIPTION
It looks like Trello changed this from a string value to an integer. I searched around in [their api docs](https://developer.atlassian.com/cloud/trello/rest/api-group-organizations/#api-organizations-id-get) but couldn't really find anything about this so I just assumed int (not uint, int64, etc).

Before this patch, I got an error message like this:

```
JSON decode failed on https://api.trello.com/1/organizations/<uuuid>
{"id":"uuuid","name":"lorem-ipsum","displayName":"Lorem Ipsum","desc":"","descData":{"emoji":{}},"url":"https://trello.com/w/lorem-ipsum","website":"http://example.com/","teamType":null,"logoHash":"affffe","logoUrl":"https://trello-logos.s3.amazonaws.com/some-uid","offering":"trello.business_class","products":[110],"powerUps":[110]}: json: cannot unmarshal number into Go struct field Organization.products of type string
